### PR TITLE
Fix version number to 5.0

### DIFF
--- a/5.0/media_matrix.json
+++ b/5.0/media_matrix.json
@@ -1,6 +1,6 @@
 {
   "zabbix_export": {
-    "version": "5.2",
+    "version": "5.0",
     "date": "2021-02-24T14:57:02Z",
     "media_types": [
       {

--- a/5.0/media_matrix.yml
+++ b/5.0/media_matrix.yml
@@ -1,5 +1,5 @@
 zabbix_export:
-  version: "5.2"
+  version: "5.0"
   date: "2021-02-24T14:57:02Z"
   media_types:
     - name: Matrix


### PR DESCRIPTION
The current files in the 5.0 directory contain the version 5.2, which makes it impossible to import them in zabbix 5.0 .
This PR changes the versions to 5.0, which makes it possible to import in zabbix 5.0.