### PR TITLE
docs: add link to how to send messages documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In order to configure the webhook, you will have to know:
 
 - [How to import media types](https://www.zabbix.com/documentation/current/manual/xml_export_import/media)
 - [How to configure webhooks](https://www.zabbix.com/documentation/current/manual/config/notifications/media/webhook)
-- [To to send messages in Zabbix](https://www.zabbix.com/documentation/6.4/en/manual/config/notifications/action/operation/message)
+- [To to send messages in Zabbix](https://www.zabbix.com/documentation/current/manual/config/notifications/action/operation/message)
 
 First, [import](https://www.zabbix.com/documentation/current/manual/xml_export_import/media#importing) the Matrix webhook into your Zabbix installation:
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Changed the readme file so it includes a line to the zabbix manual about configuring messages.
Otherwise you'll be going around in circles why no messages appears in the room altough the tests are succesful.

<!-- When this PR is merged, the title and body will be -->
Updateded Readme

